### PR TITLE
ci: split the fast and slow lanes

### DIFF
--- a/.github/workflows/build_env.yml
+++ b/.github/workflows/build_env.yml
@@ -1,51 +1,71 @@
-name: Template smoke test
+# Slow lane — full conda environment verification.
+# 慢车道 —— 完整 conda 环境安装验证。
+#
+# This is the ORIGINAL purpose of this file: prove the documented conda
+# environment still installs. That is a real question worth answering —
+# it just should not gate every commit.
+# 这正是本文件**最初的目的**：验证文档里那套 conda 环境还装得起来。
+# 这个问题确实值得回答 —— 只是不该卡住每一次提交。
+#
+# Dependency drift happens on a WEEKLY timescale, not a per-commit one.
+# Running a 20-minute CUDA install on every push spends the highest
+# possible frequency detecting the lowest-frequency event.
+# 依赖漂移是**按周**发生的，不是按 commit。每次 push 都跑一遍 20 分钟的
+# CUDA 安装，等于用最高频率去检测最低频事件。
+#
+# Failing here does NOT block day-to-day work — but you still find out
+# within a week if the environment has rotted.
+# 这里失败**不会挡住日常提交**，但环境真烂了你一周内就会知道。
+name: Build env (full conda)
 
-on: [push, pull_request]
+on:
+  workflow_dispatch:            # manual / 手动触发
+  push:
+    branches: [dev]             # TEMPORARY: validate this lane once, removed before merge
+                                # 临时：验证这条慢车道一次，合并前移除
+  schedule:
+    - cron: '0 18 * * 0'        # every Sunday 18:00 UTC / 每周日 UTC 18:00
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
 
 jobs:
-  smoke-test:
+  build-env:
     runs-on: ubuntu-latest
+    timeout-minutes: 60         # conda solving CUDA deps is slow / conda 解 CUDA 依赖很慢
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
+      - name: Clone JackFramework
+        run: git clone --depth 1 https://github.com/Archaic-Atom/JackFramework
 
-      # JackFramework has no install_requires, and `import JackFramework`
-      # eagerly pulls cv2, numpy, torch, PIL, django and
-      # torch.utils.tensorboard. Miss any one and the import fails before
-      # a single line of user code runs.
-      # JackFramework 的 setup.py 没有 install_requires，而
-      # `import JackFramework` 会急切加载 cv2 / numpy / torch / PIL /
-      # django / torch.utils.tensorboard —— 少装一个，导入阶段就失败。
-      - name: Install dependencies
+      # NOTE: the env name comes from environment.yml itself. The previous
+      # version of this workflow hardcoded `JackFramework-torch1.7.1` while
+      # the file declared `JackFramework-torch2.3.1`, so it updated one env
+      # and activated another.
+      # 注意：环境名取自 environment.yml 本身。旧版这里硬编码了
+      # `JackFramework-torch1.7.1`，而文件里声明的是 `JackFramework-torch2.3.1`
+      # —— 更新的是一个环境，激活的是另一个。
+      - name: Install the documented conda environment
         run: |
-          python -m pip install --upgrade pip
-          pip install torch --index-url https://download.pytorch.org/whl/cpu
-          pip install opencv-python-headless numpy pillow django tensorboard flake8
+          set -e
+          echo "$CONDA/bin" >> $GITHUB_PATH
+          export PATH="$CONDA/bin:$PATH"
+          ENV_NAME=$(grep '^name:' JackFramework/environment.yml | awk '{print $2}')
+          echo "environment.yml declares env: ${ENV_NAME}"
+          conda env update --file JackFramework/environment.yml --name "${ENV_NAME}"
+          echo "ENV_NAME=${ENV_NAME}" >> $GITHUB_ENV
 
-      - name: Install JackFramework
+      - name: Install JackFramework into that environment
         run: |
-          git clone --depth 1 https://github.com/Archaic-Atom/JackFramework
+          export PATH="$CONDA/bin:$PATH"
+          source activate "${ENV_NAME}"
           pip install ./JackFramework/Source
 
-      - name: Verify JackFramework imports
-        run: python -c "import JackFramework as jf; print('JackFramework OK')"
-
-      - name: Lint
+      - name: Verify it imports
         run: |
-          flake8 Source --count --select=E9,F63,F7,F82 --show-source --statistics
-          flake8 Source --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-
-      # The template must RUN, not merely import — this is the check that
-      # would have caught the postprocess/post_process breakage.
-      # 模板必须能**跑起来**而不只是能导入 —— 正是这一步能拦住
-      # postprocess/post_process 这类问题。
-      - name: Smoke test (train)
-        run: bash Scripts/start_train_dataset_model.sh
-
-      - name: Smoke test (test)
-        run: bash Scripts/start_test_dataset_model.sh
+          export PATH="$CONDA/bin:$PATH"
+          source activate "${ENV_NAME}"
+          python -c "import JackFramework as jf; print('JackFramework OK in', '${ENV_NAME}')"

--- a/.github/workflows/build_env.yml
+++ b/.github/workflows/build_env.yml
@@ -20,9 +20,6 @@ name: Build env (full conda)
 
 on:
   workflow_dispatch:            # manual / 手动触发
-  push:
-    branches: [dev]             # TEMPORARY: validate this lane once, removed before merge
-                                # 临时：验证这条慢车道一次，合并前移除
   schedule:
     - cron: '0 18 * * 0'        # every Sunday 18:00 UTC / 每周日 UTC 18:00
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,62 @@
+# Fast lane — runs on every push and PR.
+# 快车道 —— 每次 push 和 PR 都跑。
+#
+# Answers one question: "did this change break the contract?"
+# Import, lint, and an actual end-to-end run on synthetic data.
+# No GPU, no CUDA, no real dataset — none of which this can verify anyway.
+# 只回答一个问题：「这次改动有没有把契约弄坏？」
+# 导入、lint、以及在合成数据上真正跑一遍完整流程。
+# 不需要 GPU / CUDA / 真实数据集 —— 这台机器本来也验证不了那些。
+name: Smoke test
+
+on: [push, pull_request]
+
+# Cancel superseded runs instead of queueing them up.
+# 连续 push 时取消旧的运行，而不是排队堆积。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: requirements-ci.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install -r requirements-ci.txt
+
+      - name: Install JackFramework
+        run: |
+          git clone --depth 1 https://github.com/Archaic-Atom/JackFramework
+          pip install ./JackFramework/Source
+
+      - name: Verify JackFramework imports
+        run: python -c "import JackFramework as jf; print('JackFramework OK')"
+
+      - name: Lint
+        run: |
+          flake8 Source --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 Source --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+      # The template must RUN, not merely import — this is the check that
+      # would have caught the postprocess/post_process breakage.
+      # 模板必须能**跑起来**而不只是能导入 —— 正是这一步能拦住
+      # postprocess/post_process 这类问题。
+      - name: Smoke test (train)
+        run: bash Scripts/start_train_dataset_model.sh
+
+      - name: Smoke test (test)
+        run: bash Scripts/start_test_dataset_model.sh

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,0 +1,26 @@
+# CI-only dependency set / 仅供 CI 使用的依赖表
+#
+# JackFramework's setup.py declares no install_requires, so `pip install`
+# brings in nothing. These are the packages `import JackFramework` pulls
+# EAGERLY — measured by diffing sys.modules across the import, not guessed.
+# Miss any one and the import fails before a single line of user code runs.
+#
+# JackFramework 的 setup.py 没有声明 install_requires，`pip install` 不会
+# 带任何依赖。下面是 `import JackFramework` **急切加载**的包 —— 通过对比
+# 导入前后的 sys.modules 实测得出，不是猜的。少装一个，导入阶段就失败。
+#
+# torch is installed separately from the CPU-only index (see the workflow):
+# the default PyPI wheel drags in ~2.5GB of CUDA that a GPU-less runner
+# can never use.
+# torch 单独从 CPU-only 源装（见 workflow）：PyPI 默认轮子会带进约 2.5GB
+# 的 CUDA，而没有 GPU 的 runner 永远用不上。
+#
+# torchvision is imported lazily and is NOT required.
+# torchvision 是懒加载的，**不需要**。
+
+opencv-python-headless
+numpy
+pillow
+django
+tensorboard
+flake8


### PR DESCRIPTION
Splits one workflow that was trying to be two things into two workflows with distinct jobs.

## Why

`build_env.yml` was written to verify that the documented conda environment still installs — a genuinely useful check. But it was wired to `on: [push]`, so every commit paid for a full CUDA-pinned conda solve on a runner that has no GPU. Dependency drift is a weekly-timescale event; running that check per commit spends the highest possible frequency detecting the lowest-frequency one.

## What changed

| Workflow | Trigger | Time | Purpose |
|---|---|---|---|
| `smoke.yml` (new) | push, PR | **50s** | did this change break the contract? |
| `build_env.yml` (rewritten) | `workflow_dispatch` + weekly cron | 4m34s | does the documented conda env still install? |

- **`smoke.yml`** — CPU-only torch, pip cache keyed on `requirements-ci.txt`, `cancel-in-progress` so consecutive pushes do not queue, `timeout-minutes: 15`. Installs, lints, then actually **runs** both launcher scripts end to end on synthetic data. Running — not merely importing — is what catches breakage like the `postprocess`/`post_process` rename.
- **`build_env.yml`** — keeps the original intent, off the commit path. Also stops hardcoding an env name: it previously updated `JackFramework-torch1.7.1` while `environment.yml` declared `JackFramework-torch2.3.1`, so it updated one environment and activated another. The name is now read from the file.
- **`requirements-ci.txt`** (new) — JackFramework declares no `install_requires`, so `pip install` brings in nothing. This list is the eager-import set (`cv2`, `numpy`, `torch`, `PIL`, `django`, `torch.utils.tensorboard`), measured by diffing `sys.modules` across `import JackFramework` rather than guessed. `torchvision` is imported lazily and is deliberately absent.

## Verification

Both lanes were run green on `dev` before this PR:

- Smoke lane — `50s` / `58s`, both launchers reach `The Application has finished successfully.`
- Conda lane — `4m34s`, `conda env update` took `258s` and `import JackFramework` succeeded in the resulting environment.

The conda lane was validated via a temporary `push: [dev]` trigger (`workflow_dispatch` is unavailable until a workflow reaches the default branch); that trigger is removed in the final commit.

## Note

Root cause worth fixing upstream: JackFramework `setup.py` declares no `install_requires`, which is why every downstream project has to rediscover its dependency set by trial and error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KF3qprKALmNFh72t52b2wJ

## Summary by Sourcery

Split CI into a fast smoke-test lane for every push/PR and a slower, scheduled conda environment verification lane.

Build:
- Introduce a `requirements-ci.txt` file capturing the minimal import-time dependencies needed for CI installs.

CI:
- Add a new `smoke.yml` workflow that runs on push/PR to install JackFramework with CPU-only torch, lint the code, and run the launcher scripts end to end with pip caching and concurrency control.
- Retarget the existing `build_env.yml` workflow to manual and weekly scheduled triggers, focusing it solely on validating that the documented conda environment in JackFramework still installs, with the env name read from `environment.yml`.