### PR TITLE
docs(readme): add build badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Template-jf
 
+[![Smoke test](https://github.com/Archaic-Atom/Template-jf/actions/workflows/smoke.yml/badge.svg?branch=master)](https://github.com/Archaic-Atom/Template-jf/actions/workflows/smoke.yml)
+[![Build env](https://github.com/Archaic-Atom/Template-jf/actions/workflows/build_env.yml/badge.svg)](https://github.com/Archaic-Atom/Template-jf/actions/workflows/build_env.yml)
 ![Python 3.10+](https://img.shields.io/badge/python-3.10+-green.svg?style=plastic)
 ![PyTorch 2.x](https://img.shields.io/badge/PyTorch%202.x-%23EE4C2C.svg?style=plastic)
 ![License MIT](https://img.shields.io/badge/license-MIT-green.svg?style=plastic)


### PR DESCRIPTION
The README carried static python/pytorch/license badges but nothing showing whether the template actually builds — the one thing a reader most wants to know before cloning a template.

Adds both lanes, as links so a red badge leads straight to the failing run:

- **Smoke test** — pinned to `?branch=master`, so it reports the state of `master` rather than whichever branch happened to run last.
- **Build env** — the weekly conda check.

Both verified `passing` by fetching the badge SVGs before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KF3qprKALmNFh72t52b2wJ

## Summary by Sourcery

Documentation:
- Add smoke test and build environment CI badges to the README so readers can see current build status and inspect runs.